### PR TITLE
Added support for passing in environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ forever-service version 0.x.x
     -h, --help                         output usage information
     -s, --script [script]              Script to run as service e.g. app.js, defaults to app.js
 
+    -e --envVars [vars]                Environment Variables for the script
+                                       e.g. -e "PORT=80 ENV=prod FOO=bar"
+
     -o --scriptOptions [options]       Command line options for the script
 
     --minUptime [value]                Minimum uptime (millis) for a script to not be considered "spinning", default 5000

--- a/bin/forever-service
+++ b/bin/forever-service
@@ -21,6 +21,9 @@ platforms.get(function(err, platform){
 		.command('install [service]')
 		.option('-s, --script [script]','Script to run as service e.g. app.js, defaults to app.js')
 		.option('','')
+		.option('-e --envVars [vars]','Environment Variables for the script')
+		.option('','e.g. -e "PORT=80 ENV=prod FOO=bar"')
+		.option('','')
 		.option('-o --scriptOptions [options]','Command line options for the script')
 		.option('','')
 		.option('--minUptime [value]','Minimum uptime (millis) for a script to not be considered "spinning", default 5000')
@@ -72,6 +75,7 @@ platforms.get(function(err, platform){
 				ctx.script = 'app.js';
 
 
+			if(options.envVars) ctx.envVars = options.envVars;
 			if(options.scriptOptions) ctx.scriptOptions = options.scriptOptions;
 			if(options.minUptime) ctx.minUptime = options.minUptime;
 			if(options.spinSleepTime) ctx.spinSleepTime = options.spinSleepTime;

--- a/templates/sysvinit/initd.template
+++ b/templates/sysvinit/initd.template
@@ -88,7 +88,7 @@ start() {
 	ulimit -u 32000
 	{% endif %}
 
-
+  {{envVars|default('')}} \
 	{{foreverPath}}forever \
 	--pidFile $PIDFILE \
 	-a \

--- a/templates/upstart/upstart.template
+++ b/templates/upstart/upstart.template
@@ -41,7 +41,7 @@ env KILLWAITTIME={{forceKillWaitTime|default('5000')}}
 
 chdir {{cwd}}
 
-exec {{foreverPath}}forever -a -l $LOGFILE --minUptime $MIN_UPTIME --spinSleepTime $SPIN_SLEEP_TIME --killSignal $KILL_SIGNAL {{foreverOptions|default('')}} --uid {{service}} start {{script|default('app.js')}}  {{scriptOptions|default('')}}
+exec {{envVars|default('')}} {{foreverPath}}forever -a -l $LOGFILE --minUptime $MIN_UPTIME --spinSleepTime $SPIN_SLEEP_TIME --killSignal $KILL_SIGNAL {{foreverOptions|default('')}} --uid {{service}} start {{script|default('app.js')}}  {{scriptOptions|default('')}}
 
 post-start script
 	echo "{{service}} started"


### PR DESCRIPTION
I've added support for passing in environment variables to the script.
You pass them in with the extra command line option: -e or --envVars.
See the "forever-service install --help" for an example.

I've only tested it on Amazon Linux so far.

This should answer Issue #9 