### PR TITLE
envVars for Upstart handled with env stanzas

### DIFF
--- a/templates/upstart/upstart.template
+++ b/templates/upstart/upstart.template
@@ -41,7 +41,13 @@ env KILLWAITTIME={{forceKillWaitTime|default('5000')}}
 
 chdir {{cwd}}
 
-exec {{envVars|default('')}} {{foreverPath}}forever -a -l $LOGFILE --minUptime $MIN_UPTIME --spinSleepTime $SPIN_SLEEP_TIME --killSignal $KILL_SIGNAL {{foreverOptions|default('')}} --uid {{service}} start {{script|default('app.js')}}  {{scriptOptions|default('')}}
+{%- if envVars|default(false) %}
+{%- for v in envVars.split(" ") %}
+env {{ v }}
+{%- endfor %}
+{%- endif %}
+
+exec {{foreverPath}}forever -a -l $LOGFILE --minUptime $MIN_UPTIME --spinSleepTime $SPIN_SLEEP_TIME --killSignal $KILL_SIGNAL {{foreverOptions|default('')}} --uid {{service}} start {{script|default('app.js')}}  {{scriptOptions|default('')}}
 
 post-start script
 	echo "{{service}} started"


### PR DESCRIPTION
Including envVars in the exec stanza, shell-style, doesn't work as expected.

More specifically: I was trying to use forever-service to run Ghost, which requires NODE_ENV=production as an environment variable, normally specified at the start of the command line as shown here. When I tried to install it as a service with forever-service, using -e to specify the variable, it failed on job start. Investigation indicated that the exec block was trying to treat 'NODE_ENV=production' as the executable, and of course not finding it.

I can't find anything in the documentation for upstart specifying whether initializing vars in an exec stanza that way should work or not, but this change sticks them in env stanzas and does work as expected. It will still fail if there are spaces in the values, since it uses spaces as a separator. There's probably a better way, but it functions.

I ran into this issue on ubuntu 14.04. If I'm understanding the mechanism correctly, it can probably be reproduced by almost anything that makes use of -e on an upstart platform.
