### PR TITLE
Allowing use of --foreverPath option even if forever is not globally installed

### DIFF
--- a/bin/forever-service
+++ b/bin/forever-service
@@ -7,7 +7,7 @@ var path = require('path');
 
 platforms.get(function(err, platform){
 	console.log('forever-service version '+require('../package.json').version+'\n');
-	if(err || !platform){		
+	if(err || !platform){
 		console.error('This platform is not yet supported by forever-service');
 		console.error('To help us add this platform, please contibute to https://github.com/zapty/forever-service\n');
 		return;
@@ -17,7 +17,7 @@ platforms.get(function(err, platform){
 
 	program
 		.version(require('../package.json').version)
-		
+
 
 	program
 		.command('install [service]')
@@ -52,7 +52,7 @@ platforms.get(function(err, platform){
 			var ctx = Object.create(platform);
 			ctx.service = service;
 
-			if(options.script) 
+			if(options.script)
 				ctx.script = options.script;
 			else
 				ctx.script = 'app.js';
@@ -85,21 +85,21 @@ platforms.get(function(err, platform){
 			if(options.logrotateDateExt) ctx.logrotateDateExt = 'dateext';
 			if(options.logrotateCompress) ctx.logrotateCompress = 'compress';
 			if(options.applyUlimits) ctx.applyUlimits = true;
-            ctx.foreverPath=path.dirname(getCmdPath('forever'));
 
-			if(options.foreverPath) {
-				var fp = options.foreverPath;
-				fp = fp.trim();
+
+			if(options.foreverPath){
+				var fp = options.foreverPath.trim();
 				if(!fp.match(/\/$/)) fp = fp+'/';
 				ctx.foreverPath = fp;
 			} else {
-                if(!ctx.foreverPath){
-                    console.error("forever not found, forever must be installed using 'npm install -g forever'");
-                    process.exit(1);
-                } else {
-                    ctx.foreverPath+="/";
-                }
-            }
+        var foreverCmd = getCmdPath('forever');
+        if(foreverCmd){
+          ctx.foreverPath = path.dirname(foreverCmd) + "/";
+        } else {
+          console.error("forever not found, forever must be installed using 'npm install -g forever'");
+          process.exit(1);
+        }
+      }
 
 			if(options.runAsUser){
 				ctx.runAsUser = options.runAsUser;
@@ -152,7 +152,7 @@ platforms.get(function(err, platform){
 				console.error('Service name missing');
 				return 3;
 			}
-			
+
 			console.log('Platform - '+platform.os);
 
 			var ctx = Object.create(platform);
@@ -179,7 +179,7 @@ platforms.get(function(err, platform){
 		console.log('  Command help:\n')
 		console.log('    forever-service install --help');
 		console.log('    forever-service delete --help\n');
-	} 
+	}
 
 });
 


### PR DESCRIPTION
If `forever` is not in the PATH , even if the `--foreverPath` option is used, forever-service was returning a `forever not found` error.
This PR should fix that issue.
