### PR TITLE
Basic support for Ubuntu 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Platforms supported
 * Amazon Linux
 * Redhat Linux
 * CentOS
-* Ubuntu (< 15.04)
+* Ubuntu (upstart, sysv fallback for >= 15.04, no systemd support)
 * Debian
 * Raspbian
 * OSMC Linux

--- a/bin/forever-service
+++ b/bin/forever-service
@@ -4,10 +4,11 @@
 var installer = require('../lib/installer');
 var platforms = require('../lib/platforms');
 var path = require('path');
+var shell = require('shelljs');
 
 platforms.get(function(err, platform){
 	console.log('forever-service version '+require('../package.json').version+'\n');
-	if(err || !platform){		
+	if(err || !platform){
 		console.error('This platform is not yet supported by forever-service');
 		console.error('To help us add this platform, please contibute to https://github.com/zapty/forever-service\n');
 		return;
@@ -17,7 +18,7 @@ platforms.get(function(err, platform){
 
 	program
 		.version(require('../package.json').version)
-		
+
 
 	program
 		.command('install [service]')
@@ -52,7 +53,7 @@ platforms.get(function(err, platform){
 			var ctx = Object.create(platform);
 			ctx.service = service;
 
-			if(options.script) 
+			if(options.script)
 				ctx.script = options.script;
 			else
 				ctx.script = 'app.js';
@@ -152,7 +153,7 @@ platforms.get(function(err, platform){
 				console.error('Service name missing');
 				return 3;
 			}
-			
+
 			console.log('Platform - '+platform.os);
 
 			var ctx = Object.create(platform);
@@ -179,7 +180,7 @@ platforms.get(function(err, platform){
 		console.log('  Command help:\n')
 		console.log('    forever-service install --help');
 		console.log('    forever-service delete --help\n');
-	} 
+	}
 
 });
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,8 +1,6 @@
 var fs = require('fs'),
-	path = require('path');
-	scriptBuilder = require('./scriptBuilder'),
-	shell = require('shelljs');
-
+	path = require('path'),
+	scriptBuilder = require('./scriptBuilder');
 
 exports.validateScriptName = function(scriptname){
 	if(scriptname && scriptname[0] === path.sep)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "walker": "~1.0.6"
   },
   "devDependencies": {
+    "fs-extra": "^0.30.0",
     "mocha": "*",
     "should": "*"
   },

--- a/templates/sysvinit/installer.js
+++ b/templates/sysvinit/installer.js
@@ -17,7 +17,8 @@ exports.initialize=function(){
 		}
 	} else if (fs.existsSync('/etc/os-release')){
 		var contents = fs.readFileSync('/etc/os-release','utf8');
-		if( contents && contents.match(/ID=(debian|bunsenlabs|raspbian|osmc|"elementary OS")/g) ){
+		if (/ID=(debian|bunsenlabs|raspbian|osmc|"elementary OS")/.test(contents) ||
+			(!fs.existsSync('/sbin/upstart') && /ID_LIKE=debian/.test(contents))) { // Matches Ubuntu 15+ with systemd only
 			return {
 				os: getPrettyName(contents),
 				platform: 'sysvinit',

--- a/templates/sysvinit/installer.js
+++ b/templates/sysvinit/installer.js
@@ -1,6 +1,4 @@
-var os = require('os'),
-    scriptBuilder = require('../../lib/scriptBuilder'),
-	async = require('async'),
+var async = require('async'),
 	shell = require('shelljs'),
 	fs = require('fs');
 
@@ -73,16 +71,13 @@ exports.install=function(ctx, scripts, callback){
 				}
 			],
 			function(err, results){
-				//if(err) console.error('Error while provisioing service\n'+err);
-				callback(err, 
-					{
+				callback(err, {
 						help: 'Commands to interact with service '+ctx.service+'\n'+
 							  'Start   - "sudo service '+ctx.service+' start"\n'+
 							  'Stop    - "sudo service '+ctx.service+' stop"\n'+
 							  'Status  - "sudo service '+ctx.service+' status"\n'+
 							  'Restart - "sudo service '+ctx.service+' restart"'
-					}
-				);
+				});
 			}
 		);
 	}

--- a/templates/upstart/installer.js
+++ b/templates/upstart/installer.js
@@ -1,17 +1,16 @@
-var os = require('os'),
-    scriptBuilder = require('../../lib/scriptBuilder'),
-	async = require('async'),
+var async = require('async'),
 	shell = require('shelljs'),
 	fs = require('fs');
 
 exports.initialize=function(){
 
-	if(fs.existsSync('/etc/lsb-release')){
+	if (fs.existsSync('/etc/lsb-release')){
 		var contents = fs.readFileSync('/etc/lsb-release','utf8');
-		var r = /DISTRIB_DESCRIPTION\=['"](.*)['"]/gm;
-		if( contents && contents.match(/(DISTRIB_ID=Ubuntu)/g) ){
-			var osmatch = r.exec(contents);
-			if(osmatch.length < 2) return;
+		if (contents && contents.match(/(DISTRIB_ID=Ubuntu)/g) ){
+			var osmatch = /DISTRIB_DESCRIPTION\=['"](.*)['"]/gm.exec(contents);
+			if (!osmatch || osmatch.length < 2) {
+				return;
+			}
 
 			return {
 				os: osmatch[1],
@@ -61,7 +60,7 @@ exports.install=function(ctx, scripts, callback){
 			],
 			function(err, results){
 				//if(err) console.error('Error while provisioing service\n'+err);
-				callback(err, 
+				callback(err,
 					{
 						help: 'Commands to interact with service '+ctx.service+'\n'+
 							  'Start   - "sudo start '+ctx.service+'"\n'+

--- a/templates/upstart/installer.js
+++ b/templates/upstart/installer.js
@@ -3,6 +3,9 @@ var async = require('async'),
 	fs = require('fs');
 
 exports.initialize=function(){
+	if (!fs.existsSync('/sbin/upstart')) {
+		return;
+	}
 
 	if (fs.existsSync('/etc/lsb-release')){
 		var contents = fs.readFileSync('/etc/lsb-release','utf8');


### PR DESCRIPTION
Added support for current Ubuntu by *ignoring* existence of systemd and using sysv init instead.

I've changed detection to be based on presence of `/sbin/upstart`, rather than Ubuntu version, because it can be optionally (re)installed on newer versions.

Plus a minor fix for `shell = require('shelljs');` accidentally creating a global variable.