### PR TITLE
Accept env vars with "=" at value

### DIFF
--- a/bin/forever-service
+++ b/bin/forever-service
@@ -66,10 +66,12 @@ platforms.get(function(err, platform){
 				ctx.envVarsNameValueArray=[];
 				for(var evi in ctx.envVarsArray){
 					var ev = ctx.envVarsArray[evi];
-					var evp = ev.split("=");
-					if(evp.length != 2){
+					var evp = ev.split(/=(.*)/);
+					if(evp.length != 3){
 						console.log("Invalid env variable "+ev);
 						process.exit(1);
+					} else {
+						evp.pop();
 					}
 					ctx.envVarsNameValueArray.push(evp);
 				}


### PR DESCRIPTION
Examples:

"a=b=c".split(/=(.*)/)
["a", "b=c", ""]

"a=".split(/=(.*)/)
["a", "", ""]

