### PR TITLE
Allow more than one = symbol in environment variable

### DIFF
--- a/bin/forever-service
+++ b/bin/forever-service
@@ -68,8 +68,11 @@ platforms.get(function(err, platform){
 					var ev = ctx.envVarsArray[evi];
 					var evp = ev.split("=");
 					if(evp.length != 2){
-						console.log("Invalid env variable "+ev);
-						process.exit(1);
+						var evp_val = ev.substring(ev.indexOf("=")+1);
+						var temp_evp = [];
+						temp_evp.push(evp[0]);
+						temp_evp.push(evp_val);
+						evp = temp_evp;
 					}
 					ctx.envVarsNameValueArray.push(evp);
 				}


### PR DESCRIPTION
See issue #78. Quick fix for having more than one = symbols int the env variable.